### PR TITLE
Ruby 1.8 compatiblity

### DIFF
--- a/lib/mongoid_optimistic_locking/lockable.rb
+++ b/lib/mongoid_optimistic_locking/lockable.rb
@@ -5,7 +5,7 @@ module Mongoid::Lockable
   extend ActiveSupport::Concern
 
   included do
-    field :_lock_version, type: Integer, default: 0
+    field :_lock_version, :type => Integer, :default => 0
     alias :atomic_selector_old :atomic_selector
 
     # add callback to save tags index
@@ -35,7 +35,7 @@ module Mongoid::Lockable
     instance_eval do
       alias :atomic_selector :atomic_selector_old
     end
-    result =  Mongoid.database.command({getlasterror: 1})
+    result =  Mongoid.database.command({:getlasterror => 1})
     unless result["updatedExisting"]
       self._lock_version -= 1
       raise Mongoid::Errors::StaleDocument.new(self.class, self)

--- a/spec/mongoid_optimistic_locking/lockable_spec.rb
+++ b/spec/mongoid_optimistic_locking/lockable_spec.rb
@@ -25,6 +25,7 @@ describe Mongoid::Lockable do
 
   it "simulate a migration situation in which _lock_version did not exist" do
     Post.update_all(_lock_version: nil)
+    @post.reload
     @post.save_optimistic!.should == true
   end
 

--- a/spec/mongoid_optimistic_locking/lockable_spec.rb
+++ b/spec/mongoid_optimistic_locking/lockable_spec.rb
@@ -19,12 +19,12 @@ end
 
 describe Mongoid::Lockable do
   before :all do
-    @post = Post.create(text: 'original-text')
+    @post = Post.create(:text => 'original-text')
     @post._lock_version.should == 1
   end
 
   it "simulate a migration situation in which _lock_version did not exist" do
-    Post.update_all(_lock_version: nil)
+    Post.update_all(:_lock_version => nil)
     @post.reload
     @post.save_optimistic!.should == true
   end
@@ -69,8 +69,8 @@ describe Mongoid::Lockable do
 
   describe "test embedded documents" do
     before :all do
-      @post = Post.create(text: 'original-text')
-      @comment = @post.comments.create!(text: 'First comment')
+      @post = Post.create(:text => 'original-text')
+      @comment = @post.comments.create!(:text => 'First comment')
     end
 
     it "saves regularly if there's no other process changing the data in the background" do


### PR DESCRIPTION
There were a few uses of 1.9 hash syntax. I switched those to the 1.8 style for backwards compatibility.
