### PR TITLE
hideous typo in example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For example:
             begin
                 post = Post.find(params[:id])
                 post.text += "---UPDATE---  " + params[:more_text]
-                post.save_optimistic!!
+                post.save_optimistic!
             rescue Mongoid::Errors::StaleDocument
                 retry
             end


### PR DESCRIPTION
the double-bang will cause pretty bad behavior of any line of code that follows (up to and including parse error -- try putting puts "foo" in line after that), negating it.
